### PR TITLE
MaxQuant: MacCoss lab changes

### DIFF
--- a/src/org/labkey/mq/MqProteinSearchViewProvider.java
+++ b/src/org/labkey/mq/MqProteinSearchViewProvider.java
@@ -57,6 +57,7 @@ public class MqProteinSearchViewProvider implements ProteinService.QueryViewProv
                 sql.append(" OR ").append(getProteinLabelCondition("pg.MajorityProteinIds", getProteinLabels(form.getIdentifier()), form.isExactMatch(), likeOperator));
                 sql.append(" OR ").append(getProteinLabelCondition("pg.ProteinNames", getProteinLabels(form.getIdentifier()), form.isExactMatch(), likeOperator));
                 sql.append(" OR ").append(getProteinLabelCondition("pg.GeneNames", getProteinLabels(form.getIdentifier()), form.isExactMatch(), likeOperator));
+                sql.append(" OR ").append(getProteinLabelCondition("pg.FastaHeaders", getProteinLabels(form.getIdentifier()), form.isExactMatch(), likeOperator));
                 sql.append(")");
                 result.addCondition(sql);
 

--- a/src/org/labkey/mq/parser/MaxQuantTsvParser.java
+++ b/src/org/labkey/mq/parser/MaxQuantTsvParser.java
@@ -198,6 +198,10 @@ public class MaxQuantTsvParser extends TsvParser
 
         // starting with 0, look for reporter intensity columns by tag number (until we get to a tag number that doesn't exist)
         int tagNumber = 0;
+        if(row.getValue(TMT_REPORTER_INTENSITY_PREFIX + tagNumber) == null)
+        {
+            tagNumber = 1; // Some datasets start with tag number 1.
+        }
         while (row.getValue(TMT_REPORTER_INTENSITY_PREFIX + tagNumber) != null)
         {
             // Issue 34088: look for the experiment name specific columns, and fall back to the summary columns if no experiment columnns exist

--- a/src/org/labkey/mq/view/proteinSearch.jsp
+++ b/src/org/labkey/mq/view/proteinSearch.jsp
@@ -19,7 +19,7 @@
                   value="<%=h(bean.getIdentifier())%>"
                   label="Protein label *"
                   forceSmallContext="true"
-                  contextContent="Search within the following fields of the Protein Group table: Protein ID, Majority Protein ID, Protein Name, and Gene Name. You can enter a comma separated list for multiple value search."
+                  contextContent="Search within the following fields of the Protein Group table: Protein ID, Majority Protein ID, Protein Name, Gene Name, and Fasta Headers. You can enter a comma separated list for multiple value search."
     />
     <labkey:input type="checkbox"
                   id="includeSubfoldersInput"


### PR DESCRIPTION
Include "Fasta Headers" column in protein search; Handle case where TMT reporter intensity columns start with tag '1' instead of '0'