### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/src/org/labkey/mq/MqController.java
+++ b/src/org/labkey/mq/MqController.java
@@ -104,11 +104,13 @@ public class MqController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class BeginAction extends SimpleViewAction
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
             return new JspView("/org/labkey/mq/view/hello.jsp");
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
             root.addChild("Max Quant Main Page");
@@ -179,6 +181,7 @@ public class MqController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class DownloadFileAction extends SimpleViewAction<DownloadFileForm>
     {
+        @Override
         public ModelAndView getView(DownloadFileForm form, BindException errors) throws Exception
         {
             if (form.getExperimentGroupId() < 0)
@@ -249,6 +252,7 @@ public class MqController extends SpringActionController
             return null;
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }

--- a/src/org/labkey/mq/MqController.java
+++ b/src/org/labkey/mq/MqController.java
@@ -109,9 +109,9 @@ public class MqController extends SpringActionController
             return new JspView("/org/labkey/mq/view/hello.jsp");
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Max Quant Main Page");
+            root.addChild("Max Quant Main Page");
         }
     }
 
@@ -249,9 +249,8 @@ public class MqController extends SpringActionController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -339,14 +338,15 @@ public class MqController extends SpringActionController
         private ExperimentGroup _experimentGroup;
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_experimentGroup != null)
             {
                 root.addChild("MaxQuant Runs", getShowRunsUrl());
                 root.addChild("Protein Groups for Experiment Group " + _experimentGroup.getId());
             }
-            return (null == getPageConfig().getTitle() ? root.addChild("Protein Groups") : root);
+            if (null == getPageConfig().getTitle())
+                root.addChild("Protein Groups");
         }
 
         @Override
@@ -396,7 +396,7 @@ public class MqController extends SpringActionController
         private ExperimentGroup _experimentGroup;
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_experimentGroup != null)
             {
@@ -404,7 +404,8 @@ public class MqController extends SpringActionController
                 root.addChild("Experiment Protein Groups", getProteinGroupsUrl(_experimentGroup.getId()));
                 root.addChild("Peptides for Experiment Group " + _experimentGroup.getId());
             }
-            return (null == getPageConfig().getTitle() ? root.addChild("Peptides") : root);
+            if (null == getPageConfig().getTitle())
+                root.addChild("Peptides");
         }
 
         @Override
@@ -455,7 +456,7 @@ public class MqController extends SpringActionController
         private ProteinGroup _proteinGroup;
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_proteinGroup != null)
             {
@@ -463,7 +464,6 @@ public class MqController extends SpringActionController
                 root.addChild("Experiment Protein Groups", getProteinGroupsUrl(_experimentGroupId));
                 root.addChild("Peptides for Protein Group " + _proteinGroup.getId());
             }
-            return root;
         }
 
         @Override
@@ -516,7 +516,7 @@ public class MqController extends SpringActionController
         private ProteinGroup _proteinGroup;
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_proteinGroup != null)
             {
@@ -524,7 +524,6 @@ public class MqController extends SpringActionController
                 root.addChild("Experiment Protein Groups", getProteinGroupsUrl(_experimentGroupId));
                 root.addChild("Experiment Details for Protein Group " + _proteinGroup.getId());
             }
-            return root;
         }
 
         @Override
@@ -611,7 +610,7 @@ public class MqController extends SpringActionController
         private Peptide _peptide;
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if (_peptide != null)
             {
@@ -619,7 +618,6 @@ public class MqController extends SpringActionController
                 root.addChild("Experiment Protein Groups", getProteinGroupsUrl(_experimentGroupId));
                 root.addChild("Evidence for Peptide " + _peptide.getId());
             }
-            return null;
         }
 
         @Override

--- a/src/org/labkey/mq/MqImportPipelineJob.java
+++ b/src/org/labkey/mq/MqImportPipelineJob.java
@@ -40,6 +40,7 @@ public class MqImportPipelineJob extends PipelineJob
         setLogFile(FT_LOG.newFile(_expData.getFile().getParentFile(), basename));
     }
 
+    @Override
     public ActionURL getStatusHref()
     {
 //        if (_runInfo.getRunId() > 0)
@@ -49,11 +50,13 @@ public class MqImportPipelineJob extends PipelineJob
         return null;
     }
 
+    @Override
     public String getDescription()
     {
         return "MaxQuant import - " + _expData.getFile().getName();
     }
 
+    @Override
     public void run()
     {
         if (!setStatus("LOADING"))

--- a/src/org/labkey/mq/MqManager.java
+++ b/src/org/labkey/mq/MqManager.java
@@ -219,6 +219,7 @@ public class MqManager
         {
             XarSource source = new AbstractFileXarSource("Wrap MaxQuant Run", container, user)
             {
+                @Override
                 public File getLogFile() throws IOException
                 {
                     throw new UnsupportedOperationException();

--- a/src/org/labkey/mq/MqModule.java
+++ b/src/org/labkey/mq/MqModule.java
@@ -97,6 +97,7 @@ public class MqModule extends DefaultModule
 
         ExperimentService.get().registerExperimentRunTypeSource(new ExperimentRunTypeSource()
         {
+            @Override
             @NotNull
             public Set<ExperimentRunType> getExperimentRunTypes(@Nullable Container container)
             {

--- a/src/org/labkey/mq/MqPipelineProvider.java
+++ b/src/org/labkey/mq/MqPipelineProvider.java
@@ -34,6 +34,7 @@ public class MqPipelineProvider extends PipelineProvider
         return Collections.singletonList(new PipelineActionConfig(actionId, PipelineActionConfig.displayState.toolbar, ACTION_LABEL, true));
     }
 
+    @Override
     public void updateFileProperties(ViewContext context, PipeRoot pr, PipelineDirectory directory, boolean includeAll)
     {
         if (!context.getContainer().hasPermission(context.getUser(), InsertPermission.class))
@@ -48,6 +49,7 @@ public class MqPipelineProvider extends PipelineProvider
 
     public static class UploadFileFilter extends FileEntryFilter
     {
+        @Override
         public boolean accept(File file)
         {
             return file.getName().equalsIgnoreCase(SummaryTemplateParser.FILE);

--- a/src/org/labkey/mq/MqSchema.java
+++ b/src/org/labkey/mq/MqSchema.java
@@ -89,6 +89,7 @@ public class MqSchema extends SimpleUserSchema
     {
         DefaultSchema.registerProvider(NAME, new DefaultSchema.SchemaProvider(module)
         {
+            @Override
             public QuerySchema createSchema(DefaultSchema schema, Module module)
             {
                 return new MqSchema(schema.getUser(), schema.getContainer());
@@ -219,6 +220,7 @@ public class MqSchema extends SimpleUserSchema
         }
     }
 
+    @Override
     public Set<String> getTableNames()
     {
         CaseInsensitiveHashSet hs = new CaseInsensitiveHashSet();

--- a/src/org/labkey/mq/model/Evidence.java
+++ b/src/org/labkey/mq/model/Evidence.java
@@ -50,6 +50,7 @@ public class Evidence extends MqEntity
         _maxQuantBestMsmsId = row.getBestMsMsId();
     }
 
+    @Override
     public int getId()
     {
         return _id;

--- a/src/org/labkey/mq/model/ModifiedPeptide.java
+++ b/src/org/labkey/mq/model/ModifiedPeptide.java
@@ -25,11 +25,13 @@ public class ModifiedPeptide extends MqEntity
         _mass = row.getMass();
     }
 
+    @Override
     public int getId()
     {
         return _id;
     }
 
+    @Override
     public void setId(int id)
     {
         _id = id;

--- a/src/org/labkey/mq/model/Peptide.java
+++ b/src/org/labkey/mq/model/Peptide.java
@@ -31,11 +31,13 @@ public class Peptide extends MqEntity
         _mass = row.getMass();
     }
 
+    @Override
     public int getId()
     {
         return _id;
     }
 
+    @Override
     public void setId(int id)
     {
         _id = id;

--- a/src/org/labkey/mq/model/ProteinGroup.java
+++ b/src/org/labkey/mq/model/ProteinGroup.java
@@ -53,11 +53,13 @@ public class ProteinGroup extends MqEntity
         _contaminant = row.isContaminant();
     }
 
+    @Override
     public int getId()
     {
         return _id;
     }
 
+    @Override
     public void setId(int id)
     {
         _id = id;

--- a/src/org/labkey/mq/parser/ProteinGroupsParser.java
+++ b/src/org/labkey/mq/parser/ProteinGroupsParser.java
@@ -393,6 +393,7 @@ public class ProteinGroupsParser extends MaxQuantTsvParser
             _ratioCount = ratioCount;
         }
 
+        @Override
         public boolean hasRatioVals()
         {
             return super.hasRatioVals() || _ratioCount != null;

--- a/test/src/org/labkey/test/pages/maxquant/ExperimentGroupDetails.java
+++ b/test/src/org/labkey/test/pages/maxquant/ExperimentGroupDetails.java
@@ -38,6 +38,7 @@ public class ExperimentGroupDetails extends BaseDetailsPage<ExperimentGroupDetai
         return getGrid("ProteinGroups");
     }
 
+    @Override
     protected ElementCache newElementCache()
     {
         return new ElementCache();


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199