### PR TITLE
Output date with standard format instead of Date.toString()

### DIFF
--- a/src/org/labkey/mq/view/experimentGroupDetails.jsp
+++ b/src/org/labkey/mq/view/experimentGroupDetails.jsp
@@ -12,7 +12,7 @@
     <table>
         <tr>
             <td class="lk-form-label">Created:</td>
-            <td><%=h(bean.getCreated())%></td>
+            <td><%=formatDateTime(bean.getCreated())%></td>
         </tr>
         <tr>
             <td class="lk-form-label">Created By:</td>


### PR DESCRIPTION
#### Rationale
Output date with standard format instead of `Date.toString()`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549
