### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/src/org/labkey/mq/query/ExperimentGroupTable.java
+++ b/src/org/labkey/mq/query/ExperimentGroupTable.java
@@ -18,6 +18,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.mq.MqController;
 import org.labkey.mq.MqManager;
@@ -52,10 +53,10 @@ public class ExperimentGroupTable extends DefaultMqTable
         {
             @Override
             @NotNull
-            public String getFormattedValue(RenderContext ctx)
+            public HtmlString getFormattedHtml(RenderContext ctx)
             {
-                String result = h(getValue(ctx));
-                return new File(result).getParentFile().getName();
+                String result = (String)getValue(ctx);
+                return HtmlString.of(new File(result).getParentFile().getName());
             }
         });
 

--- a/src/org/labkey/mq/query/ProteinGroupTable.java
+++ b/src/org/labkey/mq/query/ProteinGroupTable.java
@@ -13,6 +13,9 @@ import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
+import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.mq.MqController;
@@ -54,20 +57,20 @@ public class ProteinGroupTable extends DefaultMqTable
             {
                 // The HTML encoded value
                 @Override @NotNull
-                public String getFormattedValue(RenderContext ctx)
+                public HtmlString getFormattedHtml(RenderContext ctx)
                 {
                     String multiValues = (String)getValue(ctx);
 
                     String[] values = multiValues.split(";");
-                    StringBuilder sb = new StringBuilder();
-                    String separator = "";
+                    HtmlStringBuilder sb = HtmlStringBuilder.of();
+                    HtmlString separator = HtmlString.EMPTY_STRING;
                     for(String value: values)
                     {
                         sb.append(separator);
-                        sb.append(PageFlowUtil.filter(value));
-                        separator = "<br>";
+                        sb.append(value);
+                        separator = HtmlString.unsafe("<br>");
                     }
-                    return sb.toString();
+                    return sb.getHtmlString();
                 }
             };
         }
@@ -82,26 +85,22 @@ public class ProteinGroupTable extends DefaultMqTable
         {
             return new DataColumn(colInfo)
             {
-                private String _separator = "<br>";
+                private HtmlString _separator = HtmlString.unsafe("<br>");
                 // The HTML encoded value
                 @Override @NotNull
-                public String getFormattedValue(RenderContext ctx)
+                public HtmlString getFormattedHtml(RenderContext ctx)
                 {
                     String multiValues = (String)getValue(ctx);
 
                     String[] values = multiValues.split(";");
-                    StringBuilder sb = new StringBuilder();
-                    String separator = "";
+                    HtmlStringBuilder sb = HtmlStringBuilder.of();
+                    HtmlString separator = HtmlString.EMPTY_STRING;
                     for(String value: values)
                     {
                         sb.append(separator);
-                        value = PageFlowUtil.filter(value);
                         if(UniprotAccPattern.matcher(value).matches())
                         {
-                            sb.append("<a href=\"http://www.uniprot.org/uniprot/");
-                            sb.append(value);
-                            sb.append("\">").append(value);
-                            sb.append("</a>");
+                            sb.append(new Link.LinkBuilder(value).clearClasses().href("http://www.uniprot.org/uniprot/" + value));
                         }
                         else
                         {
@@ -109,13 +108,13 @@ public class ProteinGroupTable extends DefaultMqTable
                         }
                         separator = _separator;
                     }
-                    return sb.toString();
+                    return sb.getHtmlString();
                 }
 
                 @Override
                 public void renderDetailsCellContents(RenderContext ctx, Writer out) throws IOException
                 {
-                    _separator = ", ";
+                    _separator = HtmlString.of(", ");
                     super.renderDetailsCellContents(ctx, out);
                 }
             };

--- a/src/org/labkey/mq/query/QueryLinkDisplayColumnFactory.java
+++ b/src/org/labkey/mq/query/QueryLinkDisplayColumnFactory.java
@@ -1,6 +1,5 @@
 package org.labkey.mq.query;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
@@ -24,19 +23,12 @@ public class QueryLinkDisplayColumnFactory implements DisplayColumnFactory
     private final String _tableName;
     private final String fkColumnName;
     private final String _valueColumnName;
-    private final String _displayValue;
 
     public QueryLinkDisplayColumnFactory(String tableName, String valueColumn, String fkColumnName)
-    {
-        this(tableName, valueColumn, fkColumnName, null);
-    }
-
-    public QueryLinkDisplayColumnFactory(String tableName, String valueColumn, String fkColumnName, String displayValue)
     {
         _tableName = tableName;
         _valueColumnName = valueColumn;
         this.fkColumnName = fkColumnName;
-        _displayValue = displayValue;
     }
 
     @Override
@@ -79,13 +71,6 @@ public class QueryLinkDisplayColumnFactory implements DisplayColumnFactory
                     url.addParameter("query." + fkColumnName + "~eq", fkValue);
                 }
                 return url.getLocalURIString();
-            }
-
-            @NotNull
-            @Override
-            public String getFormattedValue(RenderContext ctx)
-            {
-                return _displayValue == null ? super.getFormattedValue(ctx) : _displayValue;
             }
         };
     }


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML