### PR TITLE
Use ColumnDecorator to configure LabKey "column types"

### DIFF
--- a/src/org/labkey/mq/query/DefaultMqTable.java
+++ b/src/org/labkey/mq/query/DefaultMqTable.java
@@ -14,9 +14,5 @@ class DefaultMqTable extends FilteredTable<MqSchema>
     {
         super(table, schema, cf);
         wrapAllColumns(true);
-
-        ContainerForeignKey.initColumn(getMutableColumn("Container"), schema);
-        UserIdQueryForeignKey.initColumn(schema.getUser(), getContainer(), getMutableColumn("CreatedBy"), true);
-        UserIdQueryForeignKey.initColumn(schema.getUser(), getContainer(), getMutableColumn("ModifiedBy"), true);
     }
 }


### PR DESCRIPTION
#### Rationale
We inconsistently set up certain common "column types" e.g. ParticipantId or Container.  Use the existing ConceptURI property to register ColumnDecorators that configure these columns.

#### Related Pull Requests
https://github.com/LabKey/commonAssays/pull/316
https://github.com/LabKey/dataintegration/pull/98
https://github.com/LabKey/MaxQuant/pull/37
https://github.com/LabKey/platform/pull/2121
https://github.com/LabKey/sampleManagement/pull/528