### PR TITLE
override getRootPath for anonymous Xar class

### DIFF
--- a/src/org/labkey/mq/MqManager.java
+++ b/src/org/labkey/mq/MqManager.java
@@ -54,6 +54,7 @@ import org.labkey.mq.parser.SummaryTemplateParser;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Date;
@@ -230,6 +231,12 @@ public class MqManager
                 public File getRoot()
                 {
                     return file.getParentFile();
+                }
+
+                @Override
+                public Path getRootPath()
+                {
+                    return getRoot().toPath();
                 }
 
                 @Override


### PR DESCRIPTION
#### Rationale
Implement Path based getRootPath override method -- Couldn't fallback base method as it could potentially create circular reference.
Failed test: https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitPostgres/1534819?buildTab=overview

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/365

#### Changes
* override missing method in anonymous xar class
