### PR TITLE
Issue 47189: Error moving Skyline documents across folders

### DIFF
--- a/src/org/labkey/mq/MqDatahandler.java
+++ b/src/org/labkey/mq/MqDatahandler.java
@@ -59,12 +59,6 @@ public class MqDatahandler extends AbstractExperimentDataHandler
         MqManager.purgeDeletedExperimentGroups();
     }
 
-    @Override
-    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, int oldDataRowID) throws ExperimentException
-    {
-
-    }
-
     @Nullable
     @Override
     public Priority getPriority(ExpData data)


### PR DESCRIPTION
#### Rationale
When moving `exp.data` rows across containers as part of moving a run, the corresponding `exp.object` row is getting left behind. That's causing FK constraints when deleting the containers.

#### Changes
* Don't override the default implementation