### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/src/org/labkey/mq/query/ProteinGroupPeptideTable.java
+++ b/src/org/labkey/mq/query/ProteinGroupPeptideTable.java
@@ -1,7 +1,6 @@
 package org.labkey.mq.query;
 
 import org.labkey.api.data.BaseColumnInfo;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
@@ -60,15 +59,15 @@ public class ProteinGroupPeptideTable extends FilteredTable<MqSchema>
     protected void applyContainerFilter(ContainerFilter filter)
     {
         clearConditions(CONTAINER_FAKE_COLUMN_NAME);
-        addCondition(createContainerFilterSQL(filter, _userSchema.getContainer()), CONTAINER_FAKE_COLUMN_NAME);
+        addCondition(createContainerFilterSQL(filter), CONTAINER_FAKE_COLUMN_NAME);
     }
 
-    private SQLFragment createContainerFilterSQL(ContainerFilter filter, Container container)
+    private SQLFragment createContainerFilterSQL(ContainerFilter filter)
     {
         SQLFragment sql = new SQLFragment("ProteinGroupId IN (SELECT Id FROM ");
         sql.append(MqManager.getTableInfoProteinGroup(), "pg");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container")));
         sql.append(")");
         return sql;
     }


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5073 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5073

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
